### PR TITLE
Dark input buttons

### DIFF
--- a/dark-theme-for-google/data/theme.css
+++ b/dark-theme-for-google/data/theme.css
@@ -154,3 +154,6 @@ nav svg,
 .vk-btn {
   box-shadow: 0 0 1px !important;
 }
+:not([title]):not(.gb_xb):not(.frame):not(.input-button-container):not(.source-wrap):not(.sbhl) > input[type="submit"] {
+    background-color: #201f1f !important;
+}


### PR DESCRIPTION
Currently the background of the input buttons on the Google homepage are transparent, making them look like text blocks. This changes them to a dark grey.